### PR TITLE
Switch to Kahn sorting algorithm. Fixes #11

### DIFF
--- a/src/Helper/FluentHelper.php
+++ b/src/Helper/FluentHelper.php
@@ -11,13 +11,10 @@ use TractorCow\Fluent\Extension\FluentVersionedExtension;
 
 /**
  * This stuff needs to go back to the Fluent module. It's living here for now so that I can proceed.
- *
- * Class FluentHelper
- *
- * @package ChrisPenny\DataObjectToFixture\Helper
  */
 class FluentHelper
 {
+
     /**
      * Static internal cache data
      *
@@ -75,4 +72,5 @@ class FluentHelper
 
         return static::$cacheData[$cacheKey] = [];
     }
+
 }

--- a/src/Helper/KahnSorter.php
+++ b/src/Helper/KahnSorter.php
@@ -111,6 +111,7 @@ class KahnSorter
             if (is_array($currentNode['dependencies'])) {
                 foreach ($currentNode['dependencies'] as $dependency) {
                     $this->nodes[$dependency]['count'] -= 1;
+
                     if ($this->nodes[$dependency]['count'] === 0) {
                         $pending[] = $this->nodes[$dependency];
                     }

--- a/src/Helper/KahnSorter.php
+++ b/src/Helper/KahnSorter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace ChrisPenny\DataObjectToFixture\Helper;
+
+/**
+ * Shout out to Adrian Humphreys (@adrhumphreys) for providing this one.
+ */
+class KahnSorter
+{
+
+    /**
+     * @var array[]
+     */
+    private $nodes = [];
+
+    /**
+     * @var array
+     */
+    private $messages = [];
+
+    /**
+     * Example input:
+     * Page depends on:
+     * - Image
+     * - TaxonomyTerm
+     * - TaxonomyType
+     *
+     * TaxonomyTerm depends on:
+     * - TaxonomyType
+     *
+     * TaxonomyType and Image have no dependencies
+     *
+     * [
+     *   'Page' => [
+     *     'SilverStripe\Assets\Image',
+     *     'SilverStripe\Taxonomy\TaxonomyTerm',
+     *     'SilverStripe\Taxonomy\TaxonomyType',
+     *   ],
+     *   'SilverStripe\Taxonomy\TaxonomyTerm' => [
+     *     'SilverStripe\Taxonomy\TaxonomyType',
+     *   ],
+     *   'SilverStripe\Taxonomy\TaxonomyType' => [],
+     *   'SilverStripe\Assets\Image' => [],
+     * ]
+     * @param array[] $nodes
+     */
+    public function __construct(array $nodes)
+    {
+        foreach ($nodes as $key => $dependencies) {
+            $this->nodes[$key] = [
+                'name' => $key,
+                'dependencies' => $dependencies ?? [],
+                'count' => 0,
+            ];
+
+            // We do this since we want to support unspecified dependencies
+            foreach ($dependencies as $dependency) {
+                // A more informed version of it has been set
+                if (isset($this->nodes[$dependency])) {
+                    continue;
+                }
+
+                $this->nodes[$dependency] = [
+                    'name' => $dependency,
+                    'dependencies' => [],
+                    'count' => 0,
+                ];
+            }
+        }
+
+        foreach ($this->nodes as $node) {
+            $name = $node['name'];
+            $edges = [];
+
+            if (is_array($node['dependencies'])) {
+                foreach ($node['dependencies'] as $edge) {
+                    $edges[] = $edge;
+                }
+            }
+
+            $this->messages[] = sprintf(
+                '[Dependency resolution] %s depends on [%s]',
+                $name,
+                implode(',', $edges)
+            );
+        }
+    }
+
+    public function sort(): array
+    {
+        $pending = [];
+
+        foreach ($this->nodes as $node) {
+            foreach ($node['dependencies'] as $dependency) {
+                $this->nodes[$dependency]['count'] += 1;
+            }
+        }
+
+        foreach ($this->nodes as $node) {
+            if ($node['count'] === 0) {
+                $pending[] = $node;
+            }
+        }
+
+        $output = [];
+
+        while (count($pending) > 0) {
+            $currentNode = array_pop($pending);
+            $output[] = $currentNode['name'];
+
+            if (is_array($currentNode['dependencies'])) {
+                foreach ($currentNode['dependencies'] as $dependency) {
+                    $this->nodes[$dependency]['count'] -= 1;
+                    if ($this->nodes[$dependency]['count'] === 0) {
+                        $pending[] = $this->nodes[$dependency];
+                    }
+                }
+            }
+        }
+
+        foreach ($this->nodes as $node) {
+            if ($node['count'] !== 0) {
+                $this->messages[] = sprintf(
+                    'Node `%s` has `%s` left over dependencies',
+                    $node['name'],
+                    $node['count']
+                );
+            }
+        }
+
+        return array_reverse($output);
+    }
+
+}

--- a/src/Manifest/FixtureManifest.php
+++ b/src/Manifest/FixtureManifest.php
@@ -6,13 +6,9 @@ use ChrisPenny\DataObjectToFixture\ORM\Group;
 use ChrisPenny\DataObjectToFixture\ORM\Record;
 use Exception;
 
-/**
- * Class Manifest
- *
- * @package App\Module
- */
 class FixtureManifest
 {
+
     /**
      * @var Group[]
      */
@@ -70,40 +66,4 @@ class FixtureManifest
         return $this->groups;
     }
 
-    /**
-     * @return Group[]
-     */
-    public function getGroupsPrioritised(): array
-    {
-        $groups = $this->groups;
-
-        // Sort 'em! Highest priority number comes first (rendered at the top of the fixture file).
-        uasort($groups, function (Group $a, Group $b) {
-            if ($a->getPriority() == $b->getPriority()) {
-                return 0;
-            }
-
-            return ($a->getPriority() > $b->getPriority()) ? -1 : 1;
-        });
-
-        return $groups;
-    }
-
-    /**
-     * @return int
-     */
-    public function findMaxPriority(): int
-    {
-        // 0 is the default priority. If we have no groups, then the highest priority is 0.
-        if (count($this->groups) === 0) {
-            return 0;
-        }
-
-        $groups = $this->getGroupsPrioritised();
-
-        /** @var Group $highestGroup */
-        $highestGroup = array_shift($groups);
-
-        return $highestGroup->getPriority();
-    }
 }

--- a/src/Manifest/RelationshipManifest.php
+++ b/src/Manifest/RelationshipManifest.php
@@ -2,15 +2,17 @@
 
 namespace ChrisPenny\DataObjectToFixture\Manifest;
 
+use ChrisPenny\DataObjectToFixture\Helper\KahnSorter;
 use ChrisPenny\DataObjectToFixture\ORM\Group;
 use Exception;
 
 class RelationshipManifest
 {
+
     /**
      * @var array
      */
-    public $relationships = [];
+    private $relationships = [];
 
     /**
      * @return array
@@ -72,4 +74,12 @@ class RelationshipManifest
         // Remove it.
         unset($this->relationships[$toClass][$key]);
     }
+
+    public function getPrioritisedOrder(): array
+    {
+        $kahnSorter = new KahnSorter($this->getRelationships());
+
+        return $kahnSorter->sort();
+    }
+
 }

--- a/src/ORM/Group.php
+++ b/src/ORM/Group.php
@@ -4,24 +4,15 @@ namespace ChrisPenny\DataObjectToFixture\ORM;
 
 use SilverStripe\Core\Injector\Injectable;
 
-/**
- * Class Group
- *
- * @package App\Module
- */
 class Group
 {
+
     use Injectable;
 
     /**
      * @var string
      */
     private $className;
-
-    /**
-     * @var int
-     */
-    private $priority = 0;
 
     /**
      * @var array|Record[]
@@ -42,31 +33,6 @@ class Group
     public function getClassName(): string
     {
         return $this->className;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPriority(): int
-    {
-        return $this->priority;
-    }
-
-    public function resetPriority(): void
-    {
-        $this->priority = 0;
-    }
-
-    /**
-     * @param int $priority
-     */
-    public function updateToHighestPriority(int $priority): void
-    {
-        if ($priority <= $this->priority) {
-            return;
-        }
-
-        $this->priority = $priority;
     }
 
     /**
@@ -125,4 +91,5 @@ class Group
     {
         return count($this->records) === 0;
     }
+
 }

--- a/src/ORM/Record.php
+++ b/src/ORM/Record.php
@@ -4,13 +4,9 @@ namespace ChrisPenny\DataObjectToFixture\ORM;
 
 use SilverStripe\Core\Injector\Injectable;
 
-/**
- * Class Record
- *
- * @package App\Module
- */
 class Record
 {
+
     use Injectable;
 
     /**
@@ -84,4 +80,5 @@ class Record
     {
         return count($this->fields) === 0;
     }
+
 }

--- a/src/Service/FixtureService.php
+++ b/src/Service/FixtureService.php
@@ -221,6 +221,7 @@ class FixtureService
         }
 
         $dbFields = $dataObject->config()->get('db');
+
         if (!is_array($dbFields)) {
             return;
         }
@@ -270,7 +271,7 @@ class FixtureService
             }
 
             // This class has requested that it not be included in relationship maps.
-            $exclude = Config::inst()->get($relationClassName, 'exclude_from_fixture_relationships');
+            $exclude = Config::inst()->get($relationFieldName, 'exclude_from_fixture_relationships');
 
             if ($exclude) {
                 continue;
@@ -292,6 +293,7 @@ class FixtureService
             if ($relationClassName == DataObject::class) {
                 continue;
             }
+
             $relatedObject = DataObject::get($relationClassName)->byID($relatedObjectID);
 
             // We expect the relationship to be a DataObject.
@@ -368,6 +370,7 @@ class FixtureService
     {
         /** @var array $hasManyRelationships */
         $hasManyRelationships = $dataObject->config()->get('has_many');
+
         if (!is_array($hasManyRelationships)) {
             return;
         }
@@ -375,12 +378,15 @@ class FixtureService
         $schema = $dataObject->getSchema();
 
         foreach ($hasManyRelationships as $relationFieldName => $relationClassName) {
+            // Relationships are sometimes defined as ClassName.FieldName. Drop the .FieldName
+            $cleanRelationshipClassName = strtok($relationClassName, '.');
             // Use Schema to make sure that this relationship has a reverse has_one created. This will throw an
             // Exception if there isn't (SilverStripe always expects you to have it).
             $schema->getRemoteJoinField($dataObject->ClassName, $relationFieldName, 'has_many');
 
             // This class has requested that it not be included in relationship maps.
-            $exclude = Config::inst()->get($relationClassName, 'exclude_from_fixture_relationships');
+            $exclude = Config::inst()->get($cleanRelationshipClassName, 'exclude_from_fixture_relationships');
+
             if ($exclude) {
                 continue;
             }
@@ -402,6 +408,7 @@ class FixtureService
     {
         /** @var array $manyManyRelationships */
         $manyManyRelationships = $dataObject->config()->get('many_many');
+
         if (!is_array($manyManyRelationships)) {
             return;
         }
@@ -418,10 +425,10 @@ class FixtureService
 
             // This many_many relationship is being excluded anyhow, so we're also all good here.
             $exclude = Config::inst()->get($relationshipValue, 'exclude_from_fixture_relationships');
+
             if ($exclude) {
                 continue;
             }
-
 
             // Ok, so, you're probably expecting the fixture to include this relationship... but it won't. Here's your
             // warning.

--- a/src/Task/GenerateFixtureFromDataObject.php
+++ b/src/Task/GenerateFixtureFromDataObject.php
@@ -12,13 +12,11 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 
 /**
- * Class GenerateFixtureFromDataObject
- *
  * @codeCoverageIgnore
- * @package ChrisPenny\DataObjectToFixture\Task
  */
 class GenerateFixtureFromDataObject extends BuildTask
 {
+
     /**
      * {@inheritDoc}
      *
@@ -223,4 +221,5 @@ class GenerateFixtureFromDataObject extends BuildTask
         echo '<p>Fixture output:</p>';
         echo sprintf('<textarea cols="90" rows="50">%s</textarea>', $service->outputFixture());
     }
+
 }

--- a/src/Tests/Helper/KahnSorterTest.php
+++ b/src/Tests/Helper/KahnSorterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace ChrisPenny\DataObjectToFixture\Tests\Helper;
+
+use ChrisPenny\DataObjectToFixture\Helper\KahnSorter;
+use SilverStripe\Dev\SapphireTest;
+
+/**
+ * Shout out to Adrian Humphreys (@adrhumphreys) for providing this one.
+ */
+class KhanSorterTest extends SapphireTest
+{
+
+    public function testSorter(): void
+    {
+        $items = [
+            'bigOlStew' => [
+                'thingy',
+                'pig',
+                'cheeseDanish',
+                'chicken',
+            ],
+            'cheeseDanish' => [
+                'flour',
+                'butter',
+                'egg',
+                'vanilla',
+                'creamCheese',
+                'sugar',
+            ],
+            'butter' => [
+                'milk',
+                'salt',
+            ],
+            'thingy' => [
+                'iron',
+                'apple',
+                'vanilla',
+            ],
+            'creamCheese' => [
+                'milk',
+                'salt',
+            ],
+            'chicken' => [
+                'worm',
+            ],
+            'worm' => [
+                'apple',
+            ],
+            'egg' => [
+                'chicken',
+            ],
+            'milk' => [
+                'cow',
+            ],
+            'cow' => [
+                'grass',
+            ],
+            'pig' => [
+                'apple',
+                'worm',
+            ],
+        ];
+
+        $sorter = new KahnSorter($items);
+        $results = $sorter->sort();
+
+        $this->assertEquals(
+            [
+                'iron',
+                'apple',
+                'vanilla',
+                'thingy',
+                'worm',
+                'pig',
+                'flour',
+                'grass',
+                'cow',
+                'milk',
+                'salt',
+                'butter',
+                'chicken',
+                'egg',
+                'creamCheese',
+                'sugar',
+                'cheeseDanish',
+                'bigOlStew',
+            ],
+            $results
+        );
+    }
+
+    public function testEmptySort(): void
+    {
+        $sorter = new KahnSorter([]);
+        $results = $sorter->sort();
+
+        $this->assertEquals([], $results);
+    }
+
+}


### PR DESCRIPTION
The previous sorting solution was a little (hah! **very**) difficult to follow. This "Kahn algorithm" is a well defined paradigm, and it means further separation of concerns.

Outputs of fixtures may change as a result of this new sorting mechanism, however the dependency outcomes should still be accurate. There has been no change to the way that I track our dependencies, and this sorting algorithm just takes in those mapped dependencies and outputs a nice ordered list for us to use after it has processed them.