### PR TITLE
Add support for many_many and looping relationships. Remove Fluent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,6 @@ $fixture = Director::baseFolder() . '/app/resources/fixture.yml';
 file_put_contents($fixture, $service->outputFixture());
 ```
 
-## Set a maximum depth to export
-
-If you are having issues with "nesting level of '256' reached", then one option is to set a maximum depth that the
-Service will attempt to export.
-
-```php
-// Instantiate the Service.
-$service = new FixtureService();
-$service->setAllowedDepth(2);
-```
-
 ## Excluding classes from export
 
 There might be some classes (like Members?) that you don't want to include in your fixture. The manifest will check

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ $page = Page::get()->byID(1);
 // Add the DataObject to the Service.
 $service->addDataObject($dataObject);
 
+// Generating the fixture can also generate new warnings
+$output = $service->outputFixture();
+
 // Check for warnings? This is somewhat important, because if you have looping relationships (which we have no way of
 // creating fixtures for at the moment) this is how you'll know about it.
 if (count($service->getWarnings()) > 0) {
@@ -91,7 +94,7 @@ if (count($service->getWarnings()) > 0) {
 }
 
 // Do something with the fixture output.
-highlight_string($service->outputFixture());
+highlight_string($output);
 
 // Or maybe save the output to a file?
 $fixture = Director::baseFolder() . '/app/resources/fixture.yml';

--- a/README.md
+++ b/README.md
@@ -25,24 +25,33 @@ composer require chrispenny/silverstripe-data-object-to-fixture
 
 ## Purpose (early stage)
 
-The purpose of this module (at this early stage) is not to create perfect fixtures, but more to provide a solid
-guideline for what your fixture should look like.
+The purpose of this module (at this early stage) is not to guarantee perfect fixtures every time, but more to provide a
+solid guideline for what your fixture should look like.
 
 For example:
 Writing unit test fixtures can be difficult, especially when you're needing to visualise the structure and relationships
 of many different DataObjects (and then add an extra layer if you're using, say, Fluent).
 
+I would also like this module to work well with the
+[Populate](https://github.com/silverstripe/silverstripe-populate) module. Please note though that you'll need to be
+running version [2.1 or greater](https://github.com/silverstripe/silverstripe-populate/releases/tag/2.1.0), as versions
+before that did not support circular relationships.
+
 ## Purpose (future development)
 
-One goal for the future of this module is for it to work in tandem with the Populate module. I would like to get to a
-stage where content authors are able to (for example) "export pages" through the CMS, so that those pages can then be
-recreated via Populate (without a dev needing to create the fixture themselves).
+My dream for this module is that I would like to get to a stage where we can confidently say that generated fixtures
+will be perfect every time.
+
+From there, I could see this being used (as an example) for testers to be able to export pages through the CMS on their
+test environments, so that those pages can then be restored at any time via (maybe) Populate. How this would work
+exactly, and whether or not it would use Populate, is still to be determined.
 
 ## Warnings
 
-This is in very, very early development stages. Please be aware that:
+This is still in early development stages. Please be aware that:
 
 - Classes might change
+- Return types might change
 - Entire paradigms on how I generate the fixtures might change
 
 What won't change:
@@ -53,14 +62,16 @@ I would not recommend that you use this module (at this stage) for any applicati
 recommend that you use it as a developer tool (EG: to help you write your own fixtures, either for tests, or to be used
 with Populate).
 
-## Dev task
+## General usage
+
+### Dev task
 
 A dev task can be found at `/dev/tasks/generate-fixture-from-dataobject`.
 
 This task will allow you to generate a fixture (output on the screen for you to copy/paste) for any DataObject that
 you have defined in your project.
 
-## General usage
+### Code use
 
 ```php
 // Instantiate the Service.
@@ -157,19 +168,6 @@ App\Models\MyModel:
 
 ## Common issues
 
-### Relationship to ElementalArea missing
-
-TL;DR: There is a looping relationship between `Page` and `ElementalArea` in later versions of Elemental. You can
-exclude the `has_one` on `ElementalArea` as follows.
-
-```
-DNADesign\Elemental\Models\ElementalArea:
-  excluded_fixture_relationships:
-    - TopPage
-```
-
-Extra info: [Issue](https://github.com/chrispenny/silverstripe-data-object-to-fixture/issues/13).
-
 ### Nesting level of '256' reached
 
 Above are three options that you can use to attempt to reduce this.
@@ -184,7 +182,8 @@ set a max depth.
 
 ### DataObject::get() cannot query non-subclass DataObject directly
 
-You might see this error if you have a relationship being defined as simply `DataObject::class`, EG:
+You might see this error if you have polymorphic relationships (relationships being defined as simply
+`DataObject::class`), EG:
 
 ```php
 private static $has_one = [

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Generate a YAML fixture from DataObjects
 - [Installation](#installation)
 - [Purpose (early stage)](#purpose-(early-stage))
 - [Purpose (future development)](#purpose-(future-development))
-- [Warnings](#warnings)
-- [Dev task](#dev-task)
 - [General usage](#general-usage)
-- [Set a maximum depth to export](#set-a-maximum-depth-to-export)
+  - [Warnings](#warnings)
+  - [Dev task](#dev-task)
 - [Excluding relationships from export](#excluding-relationships-from-export)
 - [Excluding classes from export](#excluding-classes-from-export)
 - [Common issues](#common-issues)
+  - [Parent Pages included in your export](#parent-pages-included-in-your-export) 
+  - [Node `[YourClass]` has `[x]` left over dependencies, and so could not be sorted](#node-yourclass-has-x-left-over-dependencies-and-so-could-not-be-sorted) 
+  - [Request timeout when generating fixtures](#request-timeout-when-generating-fixtures) 
+  - [DataObject::get() cannot query non-subclass DataObject directly](#dataobjectget-cannot-query-non-subclass-dataobject-directly) 
 - [Supported relationships](#supported-relationships)
-- [Unsupported relationships](#unsupported-relationships)
 - [Fluent support](#fluent-support)
 - [Future features](#future-features)
 - [Things that this module does not currently do](#things-that-this-module-does-not-currently-do)
@@ -255,7 +257,5 @@ support provided.
 ## Things that this module does not currently do
 
 - Export `_Live` tables. I hope to add `_Live` table exports soon(ish).
-- There is no ordering logic for records within the same class. This means that if you have classes that can have
-relationships to itself, the order or records might not be correct.
 - Support for exporting/saving away Asset binary files has not been added. This means that in the current state, you can
 only generate the database record for an Asset.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "tractorcow/silverstripe-fluent": ">=4.2.0",
     "slevomat/coding-standard": "^8"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9.5",
     "tractorcow/silverstripe-fluent": ">=4.2.0",
-    "slevomat/coding-standard": "~6.0"
+    "slevomat/coding-standard": "^8"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,13 @@
     }
   },
   "prefer-stable": true,
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "silverstripe/vendor-plugin": true,
+      "silverstripe/recipe-plugin": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,10 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="SilverStripe">
-    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+<?xml version="1.0"?>
+<ruleset name="project-coding-standards">
+    <description>CodeSniffer ruleset for Silverstripe coding conventions</description>
 
     <file>src</file>
     <file>tests</file>
 
+    <!-- Show progress and output sniff names on violation, and add colours -->
+    <arg value="p" />
+    <arg name="colors" />
+    <arg value="s" />
+
+    <!-- Use PSR-2 as a base standard -->
     <rule ref="PSR2">
         <!-- Allow non camel cased method names - some base SS method names are PascalCase or snake_case -->
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
@@ -12,26 +18,41 @@
         <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
     </rule>
 
+    <!-- Ensures that arrays are indented one tab stop -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+    <!-- Makes sure that any use of double quotes strings are warranted -->
+    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+
     <!-- All "use" statements must be used in the code. -->
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
-        <!-- Comments after code are fine. It's how we disable rules when we need to -->
-        <exclude name="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode.DisallowedCommentAfterCode"/>
+        <!-- Multi or single line are both fine. Feel free to remove this exclusion if you prefer to enforce single line where they're possible -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment.OneLinePropertyComment"/>
         <!-- We're not punishing folks for adding annotations (even if the method is self documenting) -->
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+        <!-- There is actually a bug with this sniffer. If you use doc annotation to disable a rule, this sniffer (sometimes) throws an "Undefined index" error -->
+        <exclude name="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode.DisallowedCommentAfterCode"/>
         <!-- Late Static Binding is used often in SS -->
         <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
         <!-- Multiline comments is what we use as a standard in SS -->
-        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
-        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
-        <!-- Write conditions like Yoda, we do not -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
+        <!-- Disabled by default, but you may be interested in reading up on Yoda conditions to see if it's -->
+        <!-- something that you would like to start using: https://en.wikipedia.org/wiki/Yoda_conditions -->
         <exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison.RequiredYodaComparison"/>
+        <!-- It's quite common when extended base SS methods or extension points, that there are unused params -->
+        <exclude name="SlevomatCodingStandard.Functions.UnusedParameter"/>
+        <!-- Allows us to namespace {} the base Page class -->
+        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceDeclaration.DisallowedBracketedSyntax"/>
         <!-- There are two rules which conflict. NewWithoutParentheses and UselessParentheses. One must be disabled -->
         <!-- We allow new Class(); rather than new Class;-->
         <exclude name="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses"/>
-        <!-- Do not require fully qualified class names -->
-        <exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName"/>
-        <exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces.NonFullyQualified"/>
+        <!-- Do not require fully qualified class names in annotation -->
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
+        <!-- We generally allow the use of any namespace -->
+        <exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
         <!-- Not something we do in SS -->
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
         <!-- Array type hint syntax is very useful -->
@@ -41,6 +62,8 @@
         <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
         <!-- allow private static -->
         <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty"/>
+        <!-- disable until php 7.3 is implemented in the project -->
+        <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/>
         <!-- Don't require traversable type hints -->
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
@@ -49,32 +72,76 @@
         <exclude name="SlevomatCodingStandard.TypeHints.UselessConstantTypeHintSniff.UselessDocComment"/>
         <!-- Even if you strictly type, there are other reasons to add a DocComment (EG: to add @codeCoverageIgnore -->
         <exclude name="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
-        <!-- Sometimes need "useless annotation" to add things like @codeCoverageIgnore -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation"/>
-        <!-- Whitespace above and below the class doesn't do much -->
-        <exclude name="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces.NoEmptyLineAfterOpeningBrace"/>
-        <exclude name="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces.NoEmptyLineBeforeClosingBrace"/>
-        <!-- Inline doc comments are fine -->
-        <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
-        <!-- Do not require literal separator for long int values -->
-        <exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator"/>
-        <!-- Do not require arrow functions (this feature is actually not supported in our version of PHPUnit) -->
-        <exclude name="SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction"/>
-        <!-- Do not require trailing comma in function calls until we're sure we only want PHP 7.4+ support -->
-        <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/>
-        <!-- Do not require fully qualified exceptions namespaces like SilverStripe\ORM\ValidationException -->
-        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions.NonFullyQualifiedException"/>
-        <!-- Do not require function referenced via a fully qualified name -->
+        <!-- No need to namespace global functions  -->
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
-        <!-- We don't control the order of declaration based on access level -->
-        <exclude name="SlevomatCodingStandard.Classes.ClassStructure"/>
-        <!-- Allow our exceptions to have the word "Exception" in them -->
-        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
-        <!-- Allow short ternary operator -->
+        <!-- Inline doc comments are fine. We use them all the time to describe things like $dataList->first() -->
+        <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
+        <!-- Allow "useless" annotations -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
+        <!-- Allow "useless" inhreit docs -->
+        <exclude name="SlevomatCodingStandard.Commenting.UselessInheritDocComment.UselessInheritDocComment"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation"/>
+        <!-- We don't require arrow function -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction"/>
+        <!-- We don't require this -->
+        <exclude name="SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireSingleLineCall.RequiredSingleLineCall"/>
+        <exclude name="SlevomatCodingStandard.Functions.StrictCall.StrictParameterMissing"/>
+        <!-- Allows us to use $var++ and $var\-\- to incredement/decrement -->
+        <exclude name="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators" />
+        <!-- It is acceptable within Silverstripe to pass by reference for extension hooks -->
+        <exclude name="SlevomatCodingStandard.PHP.DisallowReference.DisallowedPassingByReference"/>
+        <!-- Ternary shorthand is acceptable -->
         <exclude name="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator.DisallowedShortTernaryOperator"/>
-        <!-- You are not making me go \PHP_EOL -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator.MultiLineTernaryOperatorNotUsed"/>
+        <!-- SS typically uses superfluous suffixes -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
+        <!-- Global constants and exceptions do not need to be fully qualified -->
         <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants.NonFullyQualified"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions.NonFullyQualifiedException"/>
+        <!-- Don't require literal numeric seperator (EG: 1_000 to represent 1000) -->
+        <exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator.RequiredNumericLiteralSeparator"/>
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+        <!-- Allow use of superglobals -->
+        <exclude name="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable"/>
+        <!-- Don't really care about group order. We kinda do, but not enough to enforce -->
+        <exclude name="SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder"/>
+        <!-- We do not require trailing commas on multiline methods. Both rules disabled, as we'll allow folks to -->
+        <!-- add them if they want them, but we don't enforce either way -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall.DisallowedTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration.DisallowedTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse.DisallowedTrailingComma"/>
+        <!-- Length does not determine complexity. We do not care if methods or files are long -->
+        <exclude name="SlevomatCodingStandard.Functions.FunctionLength.FunctionLength"/>
+        <exclude name="SlevomatCodingStandard.Files.FunctionLength.FunctionLength"/>
+        <exclude name="SlevomatCodingStandard.Files.FileLength.FileTooLong"/>
+        <exclude name="SlevomatCodingStandard.Classes.ClassLength.ClassTooLong"/>
+        <!-- Don't force our projects to use getters/setters for any/all properties -->
+        <exclude name="SlevomatCodingStandard.Classes.ForbiddenPublicProperty.ForbiddenPublicProperty"/>
+        <!-- We can't declare classes as abstract/final because we have plenty of instances where classes are both -->
+        <!-- used themselves, and also extended (EG: almost all of our DataObjects) -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireAbstractOrFinal.ClassNeitherAbstractNorFinal"/>
+        <!-- There are two conflicting rules. We have to pick one. We've opted to *allow* Catches that do not use -->
+        <!-- the Exception that was thrown (EG: We might be returning some other message) -->
+        <exclude name="SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch.DisallowedNonCapturingCatch"/>
+        <!-- We pass variables by reference all the time, especially as part of modules and extension points-->
+        <exclude name="SlevomatCodingStandard.PHP.DisallowReference.DisallowedInheritingVariableByReference"/>
+        <!-- We need to decide if we're specifically going to allow (and enforce) null safe object operators or not -->
+        <!-- We've opted to enforce them -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator.DisallowedNullSafeObjectOperator"/>
+        <!-- Teams have mixed preferences around whether to enforce property promotion or not. Both rules disabled -->
+        <!-- by default, and each team/project can decide for themselves how they wish to handle them -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion.RequiredConstructorPropertyPromotion"/>
+        <exclude name="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion.DisallowedConstructorPropertyPromotion"/>
+        <!-- Complexity check often fails at getCMSFields(). -->
+        <!-- Each team/project can decide if they'd prefer to just tweak the complexity level rather than exclude this rule -->
+        <exclude name="SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
@@ -89,6 +156,13 @@
             <!-- Set the root namespace for our src dir and phpunit dir. Please change these as required -->
             <property name="rootNamespaces" type="array" value="src=>ChrisPenny\DataObjectToFixture,tests=>ChrisPenny\DataObjectToFixture\Tests"/>
             <property name="ignoredNamespaces" type="array" value="Slevomat\Services"/>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
+        <properties>
+            <property name="linesCountAfterWhenLastInCaseOrDefault" value="1"/>
+            <property name="linesCountAfterWhenLastInLastCaseOrDefault" value="0"/>
         </properties>
     </rule>
 </ruleset>

--- a/src/Manifest/FixtureManifest.php
+++ b/src/Manifest/FixtureManifest.php
@@ -34,7 +34,7 @@ class FixtureManifest
     /**
      * @param string|int $id
      */
-    public function getRecordByClassNameID(string $className, $id): ?Record
+    public function getRecordByClassNameId(string $className, $id): ?Record
     {
         $group = $this->getGroupByClassName($className);
 
@@ -42,7 +42,7 @@ class FixtureManifest
             return null;
         }
 
-        return $group->getRecordByID($id);
+        return $group->getRecordById($id);
     }
 
     /**

--- a/src/Manifest/RelationshipManifest.php
+++ b/src/Manifest/RelationshipManifest.php
@@ -101,7 +101,7 @@ class RelationshipManifest
         // Again though, remember that we don't know if the relationship was defined with dot notations by the dev
 
         // Let's search to see if we can find our $from (dot notation) as a value in the array
-        $relationshipFrom = array_search($from, $this->manyManyRelationships);
+        $relationshipFrom = array_search($from, $this->manyManyRelationships, true);
 
         // Again, remember that these relationships are unique and can't be polymorphic, so if we find this particular
         // dot notation as a value, then it means we have already tracked this relationship
@@ -125,7 +125,7 @@ class RelationshipManifest
         [$toClass] = explode('.', $to);
 
         // Let's search to see if we can find just the $fromClass (without dot notation)
-        $relationshipsFrom = array_keys($this->manyManyRelationships, $fromClass);
+        $relationshipsFrom = array_keys($this->manyManyRelationships, $fromClass, true);
 
         // Because we are searching for non-dot notation, it's possible that we have received multiple results for
         // classes that relate to our $fromClass

--- a/src/Manifest/RelationshipManifest.php
+++ b/src/Manifest/RelationshipManifest.php
@@ -46,17 +46,17 @@ class RelationshipManifest
     /**
      * @throws Exception
      */
-    public function addRelationship(Group $from, Group $to): void
+    public function addRelationship(string $from, string $to): void
     {
-        if (!array_key_exists($from->getClassName(), $this->relationships)) {
-            $this->relationships[$from->getClassName()] = [];
+        if (!array_key_exists($from, $this->relationships)) {
+            $this->relationships[$from] = [];
         }
 
-        if (in_array($to->getClassName(), $this->relationships[$from->getClassName()], true)) {
+        if (in_array($to, $this->relationships[$from], true)) {
             return;
         }
 
-        $this->relationships[$from->getClassName()][] = $to->getClassName();
+        $this->relationships[$from][] = $to;
     }
 
     public function hasManyManyThroughRelationship(string $throughClass): bool

--- a/src/Manifest/RelationshipManifest.php
+++ b/src/Manifest/RelationshipManifest.php
@@ -14,6 +14,8 @@ class RelationshipManifest
 
     private array $excludedRelationships = [];
 
+    private array $manyManyRelationships = [];
+
     public function getRelationships(): array
     {
         return $this->relationships;
@@ -44,7 +46,7 @@ class RelationshipManifest
     /**
      * @throws Exception
      */
-    public function addRelationshipFromTo(Group $from, Group $to): void
+    public function addRelationship(Group $from, Group $to): void
     {
         if (!array_key_exists($from->getClassName(), $this->relationships)) {
             $this->relationships[$from->getClassName()] = [];
@@ -57,6 +59,109 @@ class RelationshipManifest
         $this->relationships[$from->getClassName()][] = $to->getClassName();
     }
 
+    public function hasManyManyThroughRelationship(string $throughClass): bool
+    {
+        // Tracking through classes is way easier... They always have to be defined in a really structured way, and they
+        // always have to share the same through class
+        return array_key_exists($throughClass, $this->manyManyRelationships);
+    }
+
+    /**
+     * @param string $fromClass
+     * @param string $fromRelation
+     * @param string $to Could be dot notation (ClassName.RelationshipName) or it could just be a ClassName
+     * @return bool
+     */
+    public function hasManyManyRelationship(string $fromClass, string $fromRelation, string $to): bool
+    {
+        // many_many relationships can be defined on either side of the relationship (or both sides of the relationship)
+
+        // Another tricky aspect of many_many is that one (or both) sides of the relationship might have been defined
+        // using dot notation. So we just have to consider both
+
+        // We always track our relationships in $manyManyRelationships using ClassName.RelationshipName as the key
+
+        // Silverstripe does not support polymorphic many_many relationships (without a through object). So, we
+        // essentially know that each many_many relationship can only relate to one other DataObject
+
+        // We always track our relationships in $manyManyRelationships using ClassName.RelationshipName as the key,
+        // which means they're all unique
+        $from = sprintf('%s.%s', $fromClass, $fromRelation);
+
+        // Let's first check to see if our $from exists
+        $relationshipTo = $this->manyManyRelationships[$from] ?? null;
+
+        // We can see that this relationship has already been tracked as a key, so we know we're covered, we don't
+        // care about checking the $relationshipTo value (see above comment about SS not supporting polymorphic)
+        if ($relationshipTo) {
+            return true;
+        }
+
+        // Now we want to check to see if this relationship has potentially been tracked in the other direction
+        // Again though, remember that we don't know if the relationship was defined with dot notations by the dev
+
+        // Let's search to see if we can find our $from (dot notation) as a value in the array
+        $relationshipFrom = array_search($from, $this->manyManyRelationships);
+
+        // Again, remember that these relationships are unique and can't be polymorphic, so if we find this particular
+        // dot notation as a value, then it means we have already tracked this relationship
+        if ($relationshipFrom) {
+            return true;
+        }
+
+        // If the $to value was provided in dot notation, then it's also possible that this exists as a key
+        $relationshipTo = $this->manyManyRelationships[$to] ?? null;
+
+        // We can see that this relationship has already been tracked as a key, so we know we're covered, we don't
+        // care about checking the $relationshipTo value (see above comment about SS not supporting polymorphic)
+        if ($relationshipTo) {
+            return true;
+        }
+
+        // The last possibility is that our $to might not have been provided in dot notation, so we'll have to go
+        // searching for a match
+
+        // Grab the ClassName out of our $to value. It doesn't matter if $to was provided in dot notation or not
+        [$toClass] = explode('.', $to);
+
+        // Let's search to see if we can find just the $fromClass (without dot notation)
+        $relationshipsFrom = array_keys($this->manyManyRelationships, $fromClass);
+
+        // Because we are searching for non-dot notation, it's possible that we have received multiple results for
+        // classes that relate to our $fromClass
+        // If we didn't find any results above, that's fine, nothing will happen in this loop
+        foreach ($relationshipsFrom as $relationshipFrom) {
+            // We would expect the $toClass to specifically be represented at the very start of our $relationshipFrom
+            if (strpos($toClass, $relationshipFrom) === 0) {
+                return true;
+            }
+        }
+
+        // The relationship has not been tracked. What a journey
+        return false;
+    }
+
+    public function addManyManyRelationship(string $fromClass, string $fromRelation, string $to): void
+    {
+        // We always store our keys as dot notation
+        $from = sprintf('%s.%s', $fromClass, $fromRelation);
+
+        if (!array_key_exists($from, $this->manyManyRelationships)) {
+            $this->manyManyRelationships[$from] = [];
+        }
+
+        // $to value *might* be dot notation, if a developer defined it as such
+        $this->manyManyRelationships[$from][] = $to;
+    }
+
+    public function addManyManyThroughRelationship(string $throughClass): void
+    {
+        // Tracking through classes is way easier... They always have to be defined in a really structured way, and they
+        // always have to share the same through class. So, we're just setting this value to true, and we don't have to
+        // worry beyond that
+        $this->manyManyRelationships[$throughClass] = true;
+    }
+
     public function resetRelationships(): void
     {
         $this->relationships = [];
@@ -64,15 +169,15 @@ class RelationshipManifest
 
     public function removeRelationship(string $fromClass, string $toClass): void
     {
-        // Find the key for this relationship.
+        // Find the key for this relationship
         $key = array_search($fromClass, $this->relationships[$toClass], true);
 
-        // It doesn't exit, so just return.
+        // It doesn't exit, so just return
         if ($key === false) {
             return;
         }
 
-        // Remove it.
+        // Remove it
         unset($this->relationships[$toClass][$key]);
     }
 

--- a/src/Manifest/RelationshipManifest.php
+++ b/src/Manifest/RelationshipManifest.php
@@ -16,6 +16,13 @@ class RelationshipManifest
 
     private array $manyManyRelationships = [];
 
+    private KahnSorter $kahnSorter;
+
+    public function __construct()
+    {
+        $this->kahnSorter = new KahnSorter();
+    }
+
     public function getRelationships(): array
     {
         return $this->relationships;
@@ -192,11 +199,27 @@ class RelationshipManifest
         return in_array($relationshipName, $exclusions, true);
     }
 
+    public function processRelationshipManifest(): void
+    {
+        $this->kahnSorter->process($this->getRelationships());
+    }
+
     public function getPrioritisedOrder(): array
     {
-        $kahnSorter = new KahnSorter($this->getRelationships());
+        if (!$this->kahnSorter->hasProcessed()) {
+            $this->kahnSorter->process($this->getRelationships());
+        }
 
-        return $kahnSorter->sort();
+        return $this->kahnSorter->getSortedNodes();
+    }
+
+    public function getPrioritisedOrderErrors(): array
+    {
+        if (!$this->kahnSorter->hasProcessed()) {
+            $this->kahnSorter->process($this->getRelationships());
+        }
+
+        return $this->kahnSorter->getWarnings();
     }
 
     public function getExcludedRelationships(): array

--- a/src/ORM/Group.php
+++ b/src/ORM/Group.php
@@ -37,7 +37,7 @@ class Group
     /**
      * @param mixed $id
      */
-    public function getRecordByID($id): ?Record
+    public function getRecordById($id): ?Record
     {
         if (!array_key_exists($id, $this->records)) {
             return null;

--- a/src/Service/FixtureService.php
+++ b/src/Service/FixtureService.php
@@ -103,9 +103,9 @@ class FixtureService
         $this->addDataObjectDbFields($dataObject);
 
         // If the DataObject has Fluent applied, then we also need to add Localised fields
-//        if ($dataObject->hasExtension(FluentExtension::class)) {
-//            $this->addDataObjectLocalisedFields($dataObject);
-//        }
+        if ($dataObject->hasExtension(FluentExtension::class)) {
+            $this->addDataObjectLocalisedFields($dataObject);
+        }
 
         // Add direct has_one relationships
         $this->addDataObjectHasOneFields($dataObject);

--- a/src/Task/GenerateFixtureFromDataObject.php
+++ b/src/Task/GenerateFixtureFromDataObject.php
@@ -236,6 +236,7 @@ class GenerateFixtureFromDataObject extends BuildTask
         $service = FixtureService::create();
 
         $service->addDataObject($dataObject);
+        $output = $service->outputFixture();
 
         echo '<div style="clear: both;"></div>';
 
@@ -251,7 +252,7 @@ class GenerateFixtureFromDataObject extends BuildTask
         echo '</div>';
 
         echo '<p><strong>Fixture output:</strong></p>';
-        echo sprintf('<textarea cols="90" rows="50">%s</textarea>', $service->outputFixture());
+        echo sprintf('<textarea cols="90" rows="50">%s</textarea>', $output);
     }
 
     protected function outputStyles(): void

--- a/src/Task/GenerateFixtureFromDataObject.php
+++ b/src/Task/GenerateFixtureFromDataObject.php
@@ -203,8 +203,6 @@ class GenerateFixtureFromDataObject extends BuildTask
             return;
         }
 
-        $maxDepth = (int) $request->getVar('maxDepth');
-
         /** @var DataObject $dataObject */
         $dataObject = $className::get()->byID($id);
 
@@ -229,12 +227,6 @@ class GenerateFixtureFromDataObject extends BuildTask
         echo '<form class="depth-form" action="" method="get">';
         echo sprintf('<input type="hidden" name="ClassName" value="%s" />', $className);
         echo sprintf('<input type="hidden" name="ID" value="%s" />', $id);
-        echo '<label>Max allowed depth (optional):<br />';
-        echo sprintf('<input name="maxDepth" type="text" value="%s" /><br />', $maxDepth ?: '');
-        echo '<span class="note">';
-        echo 'This can be useful if you\'re hitting "Maximum function nesting level" errors. See the docs regarding';
-        echo ' "Excluding relationships from export" for more details on how you might avoid these errors';
-        echo '</span>';
         echo '</label>';
         echo '<br />';
         echo '<br />';
@@ -243,11 +235,7 @@ class GenerateFixtureFromDataObject extends BuildTask
 
         $service = FixtureService::create();
 
-        if ($maxDepth) {
-            $service->setAllowedDepth($maxDepth);
-        }
-
-        $service->processDataObject($dataObject);
+        $service->addDataObject($dataObject);
 
         echo '<div style="clear: both;"></div>';
 

--- a/src/Task/GenerateFixtureFromDataObject.php
+++ b/src/Task/GenerateFixtureFromDataObject.php
@@ -30,7 +30,7 @@ class GenerateFixtureFromDataObject extends BuildTask
      * @param HTTPRequest|mixed $request
      * @throws Exception
      */
-    public function run($request): void
+    public function run($request): void // phpcs:ignore
     {
         try {
             $this->previousExecution = ini_get('max_execution_time');

--- a/tests/Helper/KahnSorterTest.php
+++ b/tests/Helper/KahnSorterTest.php
@@ -16,12 +16,6 @@ class KhanSorterTest extends SapphireTest
     public function testSorter(): void
     {
         $items = [
-            'bigOlStew' => [
-                'thingy',
-                'pig',
-                'cheeseDanish',
-                'chicken',
-            ],
             'cheeseDanish' => [
                 'flour',
                 'butter',
@@ -34,20 +28,9 @@ class KhanSorterTest extends SapphireTest
                 'milk',
                 'salt',
             ],
-            'thingy' => [
-                'iron',
-                'apple',
-                'vanilla',
-            ],
             'creamCheese' => [
                 'milk',
                 'salt',
-            ],
-            'chicken' => [
-                'worm',
-            ],
-            'worm' => [
-                'apple',
             ],
             'egg' => [
                 'chicken',
@@ -55,47 +38,34 @@ class KhanSorterTest extends SapphireTest
             'milk' => [
                 'cow',
             ],
-            'cow' => [
-                'grass',
-            ],
-            'pig' => [
-                'apple',
-                'worm',
-            ],
+            'cow' => [],
+            'chicken' => [],
         ];
 
-        $sorter = new KahnSorter($items);
-        $results = $sorter->sort();
+        $expected = [
+            'cow',
+            'salt',
+            'milk',
+            'chicken',
+            'sugar',
+            'creamCheese',
+            'vanilla',
+            'egg',
+            'butter',
+            'flour',
+            'cheeseDanish',
+        ];
 
-        $this->assertEquals(
-            [
-                'iron',
-                'apple',
-                'vanilla',
-                'thingy',
-                'worm',
-                'pig',
-                'flour',
-                'grass',
-                'cow',
-                'milk',
-                'salt',
-                'butter',
-                'chicken',
-                'egg',
-                'creamCheese',
-                'sugar',
-                'cheeseDanish',
-                'bigOlStew',
-            ],
-            $results
-        );
+        $sorter = new KahnSorter();
+        $results = $sorter->process($items);
+
+        $this->assertEquals($expected, $results);
     }
 
     public function testEmptySort(): void
     {
-        $sorter = new KahnSorter([]);
-        $results = $sorter->sort();
+        $sorter = new KahnSorter();
+        $results = $sorter->process([]);
 
         $this->assertEquals([], $results);
     }


### PR DESCRIPTION
## Fluent support

Honestly, it wasn't really working anyway.

I think Fluent support will need a rethink before I attempt to add it again.

## `many_many` and looping relationships

Switched from a recursive loop to a `while` stack. This should remove the "infinite loop" issues that we were seeing. **Note:** You might still get timeouts.

Adding support for looping relationships (EG: `Page` `has_one` `Link`, `Link` `has_one` `Page`) is going to mean that existing exports could be quite significantly changed. EG:

* Before, if you were exporting a Page, and that Page (somehow) linked to another Page, then we would **not** export that second page.
* Now that we support looping relationships, the other Page (or Pages) **will** be exported.

I would say that this is now working as expected. If you want to export a Page, and it relies on another Page, then you do need both in your fixture. **However...** depending on how folks have been using this module, it could mean that I'm destroying its usefulness, as it's possible that some exports are about to become absolutely massive.

**Some thoughts/options:**

1. Do nothing. Always export looping relationships.
2. Provide new config/setting to (optionally) exclude looping relationships (current behaviour is still achievable).
3. Provide new config/setting to (optionally) exclude "same top level class" from exports. Kind of the same as `2.`, except that `2.` covers any looping relationship of any class. Option `3.` would just be excluding related records when they're the same class as the original record.

**Other thoughts:**

At the moment, we do have support for option `2.`, however, it is not implemented very well. Looping relationships are removed at the very end of the process (increasing the chance of a timeout), whereas they should instead be **skipped** as soon as they are detected in order to save on processing time. Basically, I don't want to keep option `2.` in its current state.

**If we decided that we need option `2.` or `3.`, then I could:**

1. Look to merge these current changes as soon as possible (adding support for `many_many` and looping relationships), and then look to add support back in for option `2.` or `3.`.
2. Delay merging these current changes until I'm able to also implement option `2.` or `3.`.

I would be keen to receive feedback from anyone who's using this module 😃 