### PR TITLE
Add (bones) LeftAndMain for import interface

### DIFF
--- a/_config/import.yml
+++ b/_config/import.yml
@@ -1,0 +1,10 @@
+---
+Name: dataobjecttofixture_import
+---
+SilverStripe\MimeValidator\MimeUploadValidator:
+  MimeTypes:
+    yml:
+      - 'application/x-yaml'
+      - 'text/plain'
+      - 'text/x-yaml'
+      - 'text/yaml'

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -1,6 +1,7 @@
 ---
 Name: dataobjecttofixture_model
 ---
+# Default behaviour is to never export Member related information
 SilverStripe\Security\Member:
   exclude_from_fixture_relationships: 1
 
@@ -12,6 +13,11 @@ SilverStripe\Security\MemberPassword:
 
 SilverStripe\Security\RememberLoginHash:
   exclude_from_fixture_relationships: 1
+
+# Describe the polymorphic relationship present in SiteTreeLink (a model provided in cms)
+SilverStripe\CMS\Model\SiteTreeLink:
+  field_classname_map:
+    ParentID: ParentClass
 
 Symbiote\QueuedJobs\Controllers\QueuedTaskRunner:
   task_blacklist:

--- a/src/Admin/Form/ImportButton.php
+++ b/src/Admin/Form/ImportButton.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ChrisPenny\DataObjectToFixture\Admin\Form;
+
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+use SilverStripe\Forms\GridField\GridFieldImportButton;
+use SilverStripe\View\ArrayData;
+use SilverStripe\View\SSViewer;
+
+class ImportButton extends GridFieldImportButton
+{
+
+    /**
+     * Essentially a copy/paste of the parent method. Unfortunately there isn't an easy way to update the title of the
+     * GridField_FormAction that is created
+     *
+     * @param GridField $gridField
+     * @return array
+     */
+    public function getHTMLFragments($gridField) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        $modalID = $gridField->ID() . '_ImportModal';
+
+        // Check for form message prior to rendering form (which clears session messages)
+        $form = $this->getImportForm();
+        $hasMessage = $form && $form->getMessage();
+
+        // Render modal
+        $template = SSViewer::get_templates_by_class(static::class, '_Modal');
+        $viewer = new ArrayData([
+            'ImportModalTitle' => $this->getModalTitle(),
+            'ImportModalID' => $modalID,
+            'ImportIframe' => $this->getImportIframe(),
+            'ImportForm' => $this->getImportForm(),
+        ]);
+        $modal = $viewer->renderWith($template)->forTemplate();
+
+        // Build action button
+        $button = new GridField_FormAction(
+            $gridField,
+            'import',
+            'Import Yaml',
+            'import',
+            []
+        );
+        $button
+            ->addExtraClass('btn btn-secondary font-icon-upload btn--icon-large action_import')
+            ->setForm($gridField->getForm())
+            ->setAttribute('data-toggle', 'modal')
+            ->setAttribute('aria-controls', $modalID)
+            ->setAttribute('data-target', sprintf('#%s', $modalID))
+            ->setAttribute('data-modal', $modal);
+
+        // If form has a message, trigger it to automatically open
+        if ($hasMessage) {
+            $button->setAttribute('data-state', 'open');
+        }
+
+        return [
+            $this->targetFragment => $button->Field(),
+        ];
+    }
+
+}

--- a/src/Admin/ImportAdmin.php
+++ b/src/Admin/ImportAdmin.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ChrisPenny\DataObjectToFixture\Admin;
+
+use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FileField;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\PermissionProvider;
+
+class ImportAdmin extends LeftAndMain implements PermissionProvider
+{
+
+    private const PERMISSION_ACCESS = 'DataObjectToFixture_ImportAdmin';
+
+    private static string $url_segment = 'fixture-import';
+
+    private static string $menu_title = 'Fixture Import';
+
+    private static string $required_permission_codes = self::PERMISSION_ACCESS;
+
+    private static array $url_handlers = [
+        'import' => 'import',
+    ];
+
+    public function getEditForm($id = null, $fields = null)
+    {
+        $form = parent::getEditForm($id, $fields);
+
+        $fields = FieldList::create([
+            FileField::create('_YmlFile', 'Upload yml file')
+                ->setAllowedExtensions(['yml']),
+        ]);
+
+        $actions = FieldList::create([
+            FormAction::create('import', 'Import from yaml')
+                ->addExtraClass('btn btn-primary'),
+        ]);
+
+        $form->setFields($fields);
+        $form->setActions($actions);
+
+        return $form;
+    }
+
+    public function import(array $data, Form $form, HTTPRequest $request): bool
+    {
+        // File wasn't properly uploaded, show a reminder to the user
+        if (empty($_FILES['_YmlFile']['tmp_name']) || file_get_contents($_FILES['_YmlFile']['tmp_name']) == '') {
+            $form->sessionMessage('Please browse for a yaml file to import1');
+
+            return false;
+        }
+
+        $form->sessionMessage('Successfully imported fixture', ValidationResult::TYPE_GOOD);
+
+        return true;
+    }
+
+}

--- a/src/Admin/Model/ImportHistory.php
+++ b/src/Admin/Model/ImportHistory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ChrisPenny\DataObjectToFixture\Admin\Model;
+
+use SilverStripe\ORM\DataObject;
+
+/**
+ * @property string $Filename
+ */
+class ImportHistory extends DataObject
+{
+
+    private static string $table_name = 'DataObjectToFixture_ImportHistory';
+
+    private static array $db = [
+        'Filename' => 'Varchar(255)',
+    ];
+
+    private static array $summary_fields = [
+        'Filename',
+        'Created',
+    ];
+
+    private static string $plural_name = 'Import History';
+
+}


### PR DESCRIPTION
I initially tried to use a `LeftAndMain`, but I just couldn't get the file uploader and notifications to work as I expected. Using the "importer" from `ModelAdmin` looks to be the way to go.

## Import Button

A little bit annoyingly, there isn't a way to easily update the Title of the field, without overriding the entire method that creates it.

I'll prob look to make a PR to framework to add a hook in there somewhere to be able to set this value, but for now, this is what we need (as far as I can tell).

## Import Flow

Pretty simple errors at the moment, just covering if no file is selected for upload:

![Screen Shot 2022-09-22 at 08 35 12](https://user-images.githubusercontent.com/505788/191607861-33d391b1-1b21-4a08-b4b6-73beeaf35de9.png)

And if you do provide a valid file, then you should have a success message:

![Screen Shot 2022-09-22 at 08 35 22](https://user-images.githubusercontent.com/505788/191607874-4c208fe0-c2a5-4b9b-a459-17be10e9a1e0.png)

And the import history should update:

![Screen Shot 2022-09-22 at 08 35 31](https://user-images.githubusercontent.com/505788/191607890-627b695c-e41d-4af4-8edd-835f915b8b4c.png)
