### PR TITLE
Bugfix: Fix for relationship name in fixture output

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -1,6 +1,7 @@
 ---
 Name: dataobjecttofixture_model
 ---
+# Default behaviour is to never export Member related information
 SilverStripe\Security\Member:
   exclude_from_fixture_relationships: 1
 
@@ -13,6 +14,12 @@ SilverStripe\Security\MemberPassword:
 SilverStripe\Security\RememberLoginHash:
   exclude_from_fixture_relationships: 1
 
+# Describe the polymorphic relationship present in SiteTreeLink (a model provided in cms)
+SilverStripe\CMS\Model\SiteTreeLink:
+  field_classname_map:
+    ParentID: ParentClass
+
+# Make sure our dev/task cannot be queued by the QueuedJobs module
 Symbiote\QueuedJobs\Controllers\QueuedTaskRunner:
   task_blacklist:
     - ChrisPenny\DataObjectToFixture\Task\GenerateFixtureFromDataObject

--- a/src/Service/FixtureService.php
+++ b/src/Service/FixtureService.php
@@ -230,9 +230,9 @@ class FixtureService
             return;
         }
 
-        foreach ($hasOneRelationships as $relationshipName => $relationClassName) {
+        foreach ($hasOneRelationships as $relationName => $relationClassName) {
             // Relationship field names (as represented in the Database) are always appended with `ID`
-            $relationFieldName = sprintf('%sID', $relationshipName);
+            $relationFieldName = sprintf('%sID', $relationName);
             // field_classname_map provides devs with the opportunity to describe polymorphic relationships (see the
             // README for details)
             $fieldClassNameMap = $dataObject->config()->get('field_classname_map');
@@ -253,7 +253,7 @@ class FixtureService
             // Check to see if this particular relationship wants to be excluded
             $excludeRelationship = $this->relationshipManifest->shouldExcludeRelationship(
                 $dataObject->ClassName,
-                $relationshipName
+                $relationName
             );
 
             // Yup, exclude this relationship
@@ -304,7 +304,7 @@ class FixtureService
             $relationshipValue = sprintf('=>%s.%s', $relatedObject->ClassName, $relatedObject->ID);
 
             // Add the relationship field to our current Record
-            $record->addFieldValue($relationFieldName, $relationshipValue);
+            $record->addFieldValue($relationName, $relationshipValue);
 
             // Add a relationship map for these Groups. That being, our origin DataObject class relies on the related
             // DataObject class (EG: Page has ElementalArea)


### PR DESCRIPTION
Before: `ParentID: '=>Page.1'` (this is incorrect, it should not be appended with `ID`)
Now: `Parent: '=>Page.1'`