### PR TITLE
Add exclude_from_fixture_relationships check in ManyManyThroughFields

### DIFF
--- a/src/Service/FixtureService.php
+++ b/src/Service/FixtureService.php
@@ -570,14 +570,6 @@ class FixtureService
             $relatedObjects = $dataObject->relField($relationFieldName);
 
             foreach ($relatedObjects as $relatedObject) {
-                // Check to see if this class has requested that it not be included in relationship maps
-                $excludeClass = Config::inst()->get($relatedObject->ClassName, 'exclude_from_fixture_relationships');
-
-                // Yup, exclude this class
-                if ($excludeClass) {
-                    continue;
-                }
-
                 // Add the related DataObject as one of our resolved relationships
                 $resolvedRelationships[] = sprintf('=>%s.%s', $relatedObject->ClassName, $relatedObject->ID);
 

--- a/src/Service/FixtureService.php
+++ b/src/Service/FixtureService.php
@@ -419,6 +419,28 @@ class FixtureService
                 continue;
             }
 
+            // Relationships are sometimes defined as ClassName.FieldName. Drop the .FieldName
+            $cleanRelationshipClassName = strtok($relationClassName, '.');
+
+            // Check to see if this class has requested that it not be included in relationship maps
+            $excludeClass = Config::inst()->get($cleanRelationshipClassName, 'exclude_from_fixture_relationships');
+
+            // Yup, exclude this class
+            if ($excludeClass) {
+                continue;
+            }
+
+            // Check to see if this particular relationship wants to be excluded
+            $excludeRelationship = $this->relationshipManifest->shouldExcludeRelationship(
+                $dataObject->ClassName,
+                $relationFieldName
+            );
+
+            // Yup, exclude this relationship
+            if ($excludeRelationship) {
+                continue;
+            }
+
             // TL;DR: many_many is really tough. Developers could choose to define it only in one direction, or in
             // both directions, and they could choose to define it either with, or without dot notation in either
             // direction
@@ -497,6 +519,17 @@ class FixtureService
                 continue;
             }
 
+            // Check to see if this particular relationship wants to be excluded
+            $excludeRelationship = $this->relationshipManifest->shouldExcludeRelationship(
+                $dataObject->ClassName,
+                $relationFieldName
+            );
+
+            // Yup, exclude this relationship
+            if ($excludeRelationship) {
+                continue;
+            }
+
             // This should always simply be defined as the class name (no dot notation)
             $throughClass = $relationshipValue['through'];
             $represented = false;
@@ -537,6 +570,14 @@ class FixtureService
             $relatedObjects = $dataObject->relField($relationFieldName);
 
             foreach ($relatedObjects as $relatedObject) {
+                // Check to see if this class has requested that it not be included in relationship maps
+                $excludeClass = Config::inst()->get($relatedObject->ClassName, 'exclude_from_fixture_relationships');
+
+                // Yup, exclude this class
+                if ($excludeClass) {
+                    continue;
+                }
+
                 // Add the related DataObject as one of our resolved relationships
                 $resolvedRelationships[] = sprintf('=>%s.%s', $relatedObject->ClassName, $relatedObject->ID);
 

--- a/tests/Service/FixtureServiceTest.php
+++ b/tests/Service/FixtureServiceTest.php
@@ -172,6 +172,84 @@ class FixtureServiceTest extends SapphireTest
         $this->assertSame($expected, $parsed);
     }
 
+    public function testManyManyTagExcludeFromFixtureRelationships(): void
+    {
+        MockTag::config()->set('exclude_from_fixture_relationships', true);
+
+        $page = MockPage::create();
+        $page->Title = 'Page Excluding Tags';
+        $page->write();
+
+        $tag = MockTag::create();
+        $tag->Title = 'Excluded Tag';
+        $tag->write();
+
+        $page->Tags()->add($tag);
+
+        $service = new FixtureService();
+        $service->addDataObject($page);
+
+        $expected = [
+            MockPage::class => [
+                $page->ID => ['Title' => 'Page Excluding Tags'],
+            ],
+        ];
+
+        $this->assertSame($expected, Yaml::parse($service->outputFixture()));
+    }
+
+    public function testManyManyPageExcludedFromFixtureRelationships(): void
+    {
+        MockPage::config()->set('excluded_fixture_relationships', ['Tags']);
+
+        $page = MockPage::create();
+        $page->Title = 'Page Excluding Tags Relation';
+        $page->write();
+
+        $tag = MockTag::create();
+        $tag->Title = 'Excluded Via Relation';
+        $tag->write();
+
+        $page->Tags()->add($tag);
+
+        $service = new FixtureService();
+        $service->addDataObject($page);
+
+        $expected = [
+            MockPage::class => [
+                $page->ID => ['Title' => 'Page Excluding Tags Relation'],
+            ],
+        ];
+
+        $this->assertSame($expected, Yaml::parse($service->outputFixture()));
+    }
+
+    public function testManyManyThroughExcludedFixtureRelationships(): void
+    {
+        MockPage::config()->set('excluded_fixture_relationships', ['ThroughTargets']);
+
+        $page = MockPage::create();
+        $page->Title = 'Page Excluding Through';
+        $page->write();
+
+        $target = MockThroughTarget::create();
+        $target->Title = 'Excluded Through Target';
+        $target->write();
+
+        $page->ThroughTargets()->add($target);
+
+        $service = new FixtureService();
+        $service->addDataObject($page);
+
+        $expected = [
+            MockPage::class => [
+                $page->ID => ['Title' => 'Page Excluding Through'],
+            ],
+        ];
+
+        $this->assertSame($expected, Yaml::parse($service->outputFixture()));
+    }
+
     public function testManyManyThroughRelationship(): void
     {
         $page = MockPage::create();


### PR DESCRIPTION
When generating fixtures of site config, it does not exclude Member and Groups.

Added the `exclude_from_fixture_relationships` check for many_many relations.